### PR TITLE
Pooler dependency change.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [warn_missing_spec]}.
 
 {deps, [
-        {pooler, "1.5.0"},
+        {pooler, {git, "https://github.com/seth/pooler.git", {tag, "1.5.2"}}},
         {epgsql, "3.3.0"},
         {herd, {git, "https://github.com/wgnet/herd", {tag, "1.3.3"}}}
        ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,9 +4,11 @@
   {git,"https://github.com/wgnet/herd",
        {ref,"7ef6954e13e854f32b02a2b97362458ed5208f8d"}},
   0},
- {<<"pooler">>,{pkg,<<"pooler">>,<<"1.5.0">>},0}]}.
+ {<<"pooler">>,
+  {git,"https://github.com/seth/pooler.git",
+       {ref,"a9fb9dbbac45000f10d8edf4464bf8425b39bd77"}},
+  0}]}.
 [
 {pkg_hash,[
- {<<"epgsql">>, <<"974A578340E52012CBAB820CE756E7ED1DF1BAF0110C59A6753D8337A2CF9454">>},
- {<<"pooler">>, <<"0FD4BE5D2976E6A2E9A1617623031758C26F200C1FCA89E4A3C542747BEC6371">>}]}
+ {<<"epgsql">>, <<"974A578340E52012CBAB820CE756E7ED1DF1BAF0110C59A6753D8337A2CF9454">>}]}
 ].


### PR DESCRIPTION
Pull request solves current problem with pooler, which is:
pooler version 1.5.0 blindly includes eunit.hrl at pooler.erl:
```
-include_lib("eunit/include/eunit.hrl").
```
Which automatically defines TEST environment variable which in its turn exports all functions defined in module:
```
%% To help with testing internal functions
-ifdef(TEST).
-compile([export_all]).
-endif.
```
Which in its turn breaks production compilation with Erlang 20.* and warnings_as_errors rebar option.
Sad but true.

Since theres no pooler 1.5.2 in hex, I had to switch to usual rebar dep definition...